### PR TITLE
Generic name for studio.config.json schema name

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2885,8 +2885,8 @@
       "url": "https://json.schemastore.org/vss-extension.json"
     },
     {
-      "name": "WebComponents.dev studio configuration file",
-      "description": "JSON schema for the WebComponents.dev configuration file",
+      "name": "<div>RIOTS' studio configuration",
+      "description": "JSON schema for the <div>RIOTS' studio configuration",
       "fileMatch": [
         "studio.config.json"
       ],


### PR DESCRIPTION
Since the configuration file can actually be used across https://webcomponents.dev/, https://components.studio/ and https://backlight.dev/ it makes more sense for its name to be more generic

Thanks :bow:

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
